### PR TITLE
Adjusted env var access and login redirect for dev environment

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,2 @@
 export const SERVER_URL =
-  import.meta.env.MODE === "development" ?
-    import.meta.env.VITE_SERVER_URL_DEV :
-    import.meta.env.VITE_SERVER_URL_PROD;
+  import.meta.env.VITE_SERVER_URL

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -13,6 +13,8 @@ import Alert, { UserAlert } from "components/alert/Alert";
 //   password: string,
 //   confirm: string,
 // }
+const VITE_URL = import.meta.env.VITE_URL;
+console.log(VITE_URL);
 
 export default function LoginForm() {
   // no auth logic yet.
@@ -31,7 +33,8 @@ export default function LoginForm() {
         options: {
           queryParams: {
             prompt: "select_account"
-          }
+          },
+          redirectTo: VITE_URL
         }
       });
     if (error) {

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -14,7 +14,6 @@ import Alert, { UserAlert } from "components/alert/Alert";
 //   confirm: string,
 // }
 const VITE_URL = import.meta.env.VITE_URL;
-console.log(VITE_URL);
 
 export default function LoginForm() {
   // no auth logic yet.

--- a/src/pages/admin/admin.tsx
+++ b/src/pages/admin/admin.tsx
@@ -70,7 +70,7 @@ export default function AdminPage() {
 
   return (
     <AdminContainer user={user}>
-      <h2><u>Admin Page:</u></h2>
+      <p><u>Admin Page:</u></p>
       <SettingsContainer
         instructors={instructorData}
         students={studentData} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,14 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   const isProd = mode === "production";
-  const VITE_SERVER_URL = isProd ? env.VITE_SERVER_URL_PROD : env.VITE_SERVER_URL_DEV;
-  const VITE_URL_DEV = env.VITE_URL_DEV;
+
+  const VITE_SERVER_URL = env.VITE_SERVER_URL
+  const VITE_URL = env.VITE_URL;
+
+  const allowedHost = isProd ?
+    VITE_URL.replace("https://", "") :
+    VITE_URL.replace("http://", "")
+
 
   return {
     plugins: [
@@ -25,7 +31,7 @@ export default defineConfig(({ mode }) => {
       }),
     ],
     server: {
-      allowedHosts: [VITE_URL_DEV.replace("https://", ""),],
+      allowedHosts: [allowedHost],
       proxy: {
         "/api": {
           target: `${VITE_SERVER_URL}`,


### PR DESCRIPTION
Setting up dev/prod environment split for authentication. Added redirect based on Vite "MODE" to Google OAuth login function - localhost if development mode, hosted domain if production mode.